### PR TITLE
resolved bug pointed out during submission, false typo alert

### DIFF
--- a/class_test/lexer.l
+++ b/class_test/lexer.l
@@ -10,7 +10,7 @@ int ascii(char * word){
     int i,a;
     for(i=0;i< strlen(word);i++){
         a = word[i];
-        sum += a;
+        sum += (a*a)  ;
         }
     return sum;
     }


### PR DESCRIPTION
Checked and verified for some examples. This minor change in code will resolve the following error:

```
dictionary words : bat,cat
entered word: bat
o/p: valid word entered
entered word: aau 
o/p:you have made a typo //as ascii sum will be same as bat
```